### PR TITLE
Remove unplugin-icons type declarations from TypeScript config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,7 @@
     "types": [
       "nuxt-windicss",
       "@vueuse/nuxt",
-      "@pinia/nuxt",
-      "unplugin-icons/types/vue"
+      "@pinia/nuxt"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- drop the unplugin-icons Vue type declarations from the tsconfig types list to avoid loading the huge generated typings during builds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d47e04e2bc83269821acef9b8b8f7e